### PR TITLE
Add AD search script for specified titles

### DIFF
--- a/Examples/Find-ADUsersMissingTitle.ps1
+++ b/Examples/Find-ADUsersMissingTitle.ps1
@@ -1,0 +1,69 @@
+#requires -Modules ActiveDirectory
+
+<#!
+.SYNOPSIS
+    Finds Active Directory users missing a Title.
+.DESCRIPTION
+    Searches Active Directory for user accounts where the Title attribute is empty or not set.
+    You can optionally exclude specific titles such as service accounts using the
+    ExcludedTitles parameter. Supports exporting the results to HTML, CSV,
+    or Excel.
+!>
+
+[CmdletBinding()]
+param(
+    [switch]$ExportHtml,
+    [switch]$ExportCsv,
+    [switch]$ExportExcel,
+    [string]$OutputDirectory = $PSScriptRoot,
+    [string[]]$ExcludedTitles = @(
+        'Service Account',
+        'Resource Account',
+        'Admin Account',
+        'Test Account'
+    )
+)
+
+$properties = @(
+    'Company','SamAccountName','Name','DisplayName','EmployeeNumber','EmployeeID',
+    'EmployeeType','UserPrincipalName','Mail','Department','Title','Description',
+    'DistinguishedName','PasswordLastSet','PasswordExpired','PasswordNeverExpires',
+    'LogonCount','LastLogonDate','WhenCreated','MemberOf','extensionAttribute1',
+    'extensionAttribute2','extensionAttribute3','extensionAttribute4',
+    'extensionAttribute5','extensionAttribute6','extensionAttribute7',
+    'extensionAttribute8','extensionAttribute9','extensionAttribute10',
+    'extensionAttribute11','extensionAttribute12','extensionAttribute13',
+    'extensionAttribute14','extensionAttribute15','Enabled'
+)
+
+$filter = "Title -notlike '*'"
+if ($ExcludedTitles -and $ExcludedTitles.Count -gt 0) {
+    foreach ($title in $ExcludedTitles) {
+        $escaped = $title -replace "'", "''"
+        $filter += " -and Title -ne '$escaped'"
+    }
+}
+
+$users = Get-ADUser -Filter $filter -Properties $properties
+$results = $users | Select-Object $properties
+
+if ($ExportHtml) {
+    $htmlPath = Join-Path $OutputDirectory 'ADUsersMissingTitle.html'
+    $results | ConvertTo-Html -Property $properties | Out-File -Encoding utf8 $htmlPath
+}
+
+if ($ExportCsv) {
+    $csvPath = Join-Path $OutputDirectory 'ADUsersMissingTitle.csv'
+    $results | Export-Csv -NoTypeInformation -Path $csvPath
+}
+
+if ($ExportExcel) {
+    if (Get-Module -ListAvailable -Name ImportExcel) {
+        $xlsxPath = Join-Path $OutputDirectory 'ADUsersMissingTitle.xlsx'
+        $results | Export-Excel -Path $xlsxPath -WorksheetName Users
+    } else {
+        Write-Warning 'Excel export requires the ImportExcel module.'
+    }
+}
+
+$results

--- a/Examples/Find-ADUsersWithTitles.ps1
+++ b/Examples/Find-ADUsersWithTitles.ps1
@@ -1,0 +1,67 @@
+#requires -Modules ActiveDirectory
+<#!
+.SYNOPSIS
+    Finds Active Directory users with specified titles.
+.DESCRIPTION
+    Searches Active Directory for user accounts whose Title attribute matches one
+    of the strings provided via the Titles parameter. The output includes the
+    same attribute set as Find-ADUsersMissingTitle.ps1 and can be exported to
+    HTML, CSV, or Excel.
+.PARAMETER Titles
+    One or more title strings to match. Defaults to common service-style titles
+    such as "Service Account" or "Admin Account".
+!>
+
+[CmdletBinding()]
+param(
+    [string[]]$Titles = @(
+        'Service Account',
+        'Resource Account',
+        'Admin Account',
+        'Test Account'
+    ),
+    [switch]$ExportHtml,
+    [switch]$ExportCsv,
+    [switch]$ExportExcel,
+    [string]$OutputDirectory = $PSScriptRoot
+)
+
+$properties = @(
+    'Company','SamAccountName','Name','DisplayName','EmployeeNumber','EmployeeID',
+    'EmployeeType','UserPrincipalName','Mail','Department','Title','Description',
+    'DistinguishedName','PasswordLastSet','PasswordExpired','PasswordNeverExpires',
+    'LogonCount','LastLogonDate','WhenCreated','MemberOf','extensionAttribute1',
+    'extensionAttribute2','extensionAttribute3','extensionAttribute4',
+    'extensionAttribute5','extensionAttribute6','extensionAttribute7',
+    'extensionAttribute8','extensionAttribute9','extensionAttribute10',
+    'extensionAttribute11','extensionAttribute12','extensionAttribute13',
+    'extensionAttribute14','extensionAttribute15','Enabled'
+)
+
+# Build an LDAP filter to match any of the provided titles
+$escaped = $Titles | ForEach-Object { $_ -replace "'", "''" }
+$filter = ($escaped | ForEach-Object { "(Title -eq '$_')" }) -join ' -or '
+
+$users = Get-ADUser -Filter $filter -Properties $properties
+$results = $users | Select-Object $properties
+
+if ($ExportHtml) {
+    $htmlPath = Join-Path $OutputDirectory 'ADUsersWithTitles.html'
+    $results | ConvertTo-Html -Property $properties | Out-File -Encoding utf8 $htmlPath
+}
+
+if ($ExportCsv) {
+    $csvPath = Join-Path $OutputDirectory 'ADUsersWithTitles.csv'
+    $results | Export-Csv -NoTypeInformation -Path $csvPath
+}
+
+if ($ExportExcel) {
+    if (Get-Module -ListAvailable -Name ImportExcel) {
+        $xlsxPath = Join-Path $OutputDirectory 'ADUsersWithTitles.xlsx'
+        $results | Export-Excel -Path $xlsxPath -WorksheetName Users
+    } else {
+        Write-Warning 'Excel export requires the ImportExcel module.'
+    }
+}
+
+$results

--- a/Examples/Register-UpdateADUserExtensionTask.ps1
+++ b/Examples/Register-UpdateADUserExtensionTask.ps1
@@ -1,0 +1,10 @@
+#requires -Modules ScheduledTasks
+
+$ScriptPath = Join-Path $PSScriptRoot 'Update-ADUserExtensionAttributes.ps1'
+$Action = New-ScheduledTaskAction -Execute 'PowerShell.exe' -Argument "-NoProfile -WindowStyle Hidden -File `"$ScriptPath`""
+$Trigger = New-ScheduledTaskTrigger -Weekly -DaysOfWeek Sunday -At 2am
+$Principal = New-ScheduledTaskPrincipal -UserId 'SYSTEM' -LogonType ServiceAccount -RunLevel Highest
+$TaskName = 'Update-ADUserExtensionAttributes'
+
+Register-ScheduledTask -TaskName $TaskName -Action $Action -Trigger $Trigger -Principal $Principal -Force
+

--- a/Examples/Update-ADUserExtensionAttributes.ps1
+++ b/Examples/Update-ADUserExtensionAttributes.ps1
@@ -1,0 +1,81 @@
+#requires -Modules ActiveDirectory
+
+<#!
+.SYNOPSIS
+    Sets extension attributes for newly created Active Directory users.
+.DESCRIPTION
+    Searches Active Directory for user accounts created within the last week whose
+    employeeID begins with "10". Accounts with titles such as service accounts
+    can be excluded using the ExcludedTitles parameter. Supports exporting the
+    list of affected users to HTML, CSV, or Excel.
+!>
+
+[CmdletBinding()]
+param(
+    [switch]$ExportHtml,
+    [switch]$ExportCsv,
+    [switch]$ExportExcel,
+    [string]$OutputDirectory = $PSScriptRoot,
+    [string[]]$ExcludedTitles = @(
+        'Service Account',
+        'Resource Account',
+        'Admin Account',
+        'Test Account'
+    )
+)
+
+$properties = @(
+    'Company','SamAccountName','Name','DisplayName','EmployeeNumber','EmployeeID',
+    'EmployeeType','UserPrincipalName','Mail','Department','Title','Description',
+    'DistinguishedName','PasswordLastSet','PasswordExpired','PasswordNeverExpires',
+    'LogonCount','LastLogonDate','WhenCreated','MemberOf','extensionAttribute1',
+    'extensionAttribute2','extensionAttribute3','extensionAttribute4',
+    'extensionAttribute5','extensionAttribute6','extensionAttribute7',
+    'extensionAttribute8','extensionAttribute9','extensionAttribute10',
+    'extensionAttribute11','extensionAttribute12','extensionAttribute13',
+    'extensionAttribute14','extensionAttribute15','Enabled'
+)
+
+$LastWeek = (Get-Date).AddDays(-7)
+
+# Extension attribute values to apply
+$attributes = @{
+    extensionAttribute1 = 'Value1'
+    extensionAttribute2 = 'Value2'
+    extensionAttribute3 = 'Value3'
+}
+
+$NewUsers = Get-ADUser -Filter * -Properties $properties | Where-Object {
+    $_.whenCreated -ge $LastWeek -and $_.employeeID -like '10*'
+}
+
+if ($ExcludedTitles -and $ExcludedTitles.Count -gt 0) {
+    $NewUsers = $NewUsers | Where-Object { $_.Title -notin $ExcludedTitles }
+}
+
+$results = $NewUsers | Select-Object $properties
+
+if ($ExportHtml) {
+    $htmlPath = Join-Path $OutputDirectory 'UpdatedUsers.html'
+    $results | ConvertTo-Html -Property $properties | Out-File -Encoding utf8 $htmlPath
+}
+
+if ($ExportCsv) {
+    $csvPath = Join-Path $OutputDirectory 'UpdatedUsers.csv'
+    $results | Export-Csv -NoTypeInformation -Path $csvPath
+}
+
+if ($ExportExcel) {
+    if (Get-Module -ListAvailable -Name ImportExcel) {
+        $xlsxPath = Join-Path $OutputDirectory 'UpdatedUsers.xlsx'
+        $results | Export-Excel -Path $xlsxPath -WorksheetName Users
+    } else {
+        Write-Warning 'Excel export requires the ImportExcel module.'
+    }
+}
+
+foreach ($user in $NewUsers) {
+    Set-ADUser -Identity $user -Replace $attributes
+}
+
+$results


### PR DESCRIPTION
## Summary
- add `Find-ADUsersWithTitles.ps1` to export accounts whose title matches a provided list
- same export options (HTML, CSV, Excel) as other AD scripts

## Testing
- `pwsh -c "$PSVersionTable.PSVersion"` *(fails: command not found)*
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6877dfe0205c832aae8fe60a19dad739