### PR TITLE
Add AD health check PowerShell scripts

### DIFF
--- a/AD-Examples/DcServicesStatus.ps1
+++ b/AD-Examples/DcServicesStatus.ps1
@@ -1,0 +1,24 @@
+<#
+.SYNOPSIS
+    Checks service status on all domain controllers.
+.DESCRIPTION
+    Verifies that core services like Active Directory Domain Services, DNS Server, Netlogon, and others are running on each domain controller.
+#>
+
+Import-Module ActiveDirectory
+
+$services = @('NTDS','DNS','Netlogon','Kdc','W32Time','DFSR')
+$dcs = Get-ADDomainController -Filter *
+
+Write-Host "=== Domain Controller Services ===" -ForegroundColor Cyan
+foreach ($dc in $dcs) {
+    Write-Host "`n$($dc.HostName)" -ForegroundColor Yellow
+    foreach ($svc in $services) {
+        $status = Get-Service -ComputerName $dc.HostName -Name $svc -ErrorAction SilentlyContinue
+        if ($status) {
+            Write-Host "$svc : $($status.Status)" -ForegroundColor Green
+        } else {
+            Write-Warning "Service $svc not found"
+        }
+    }
+}

--- a/AD-Examples/DnsHealthCheck.ps1
+++ b/AD-Examples/DnsHealthCheck.ps1
@@ -1,0 +1,46 @@
+<#
+.SYNOPSIS
+    Performs DNS health checks for domain controllers.
+.DESCRIPTION
+    Verifies that required SRV and host records exist for each domain controller,
+    checks zone transfer settings, and confirms record IP addresses.
+#>
+
+Import-Module ActiveDirectory
+Import-Module DnsServer
+
+$domain = Get-ADDomain
+$zone = $domain.DNSRoot
+$dcs = Get-ADDomainController -Filter *
+
+Write-Host "=== DNS Health Check ===" -ForegroundColor Cyan
+
+foreach ($dc in $dcs) {
+    $dcName = $dc.HostName
+    Write-Host "`n$dcName" -ForegroundColor Yellow
+
+    # Validate host A record
+    $aRecord = Get-DnsServerResourceRecord -ZoneName $zone -Name $dc.HostName.Split('.')[0] -RRType A -ErrorAction SilentlyContinue
+    if ($aRecord -and $aRecord.RecordData[0].IPv4Address.IPAddressToString -eq $dc.IPv4Address) {
+        Write-Host "A record IP matches" -ForegroundColor Green
+    } else {
+        Write-Warning "A record mismatch or missing"
+    }
+
+    # Check SRV records
+    $srvPaths = @(
+        "_ldap._tcp.$zone",
+        "_kerberos._tcp.$zone",
+        "_ldap._tcp.dc._msdcs.$zone",
+        "_kerberos._tcp.dc._msdcs.$zone"
+    )
+    foreach ($path in $srvPaths) {
+        if (-not (Resolve-DnsName -Type SRV -Name $path -DnsOnly -ErrorAction SilentlyContinue | Where-Object { $_.NameHost -eq $dcName })) {
+            Write-Warning "Missing SRV record $path for $dcName"
+        }
+    }
+}
+
+# Zone transfer settings
+Write-Host "`nZone Transfer Settings" -ForegroundColor Cyan
+Get-DnsServerZone -Name $zone | Select-Object ZoneName, ZoneType, AllowZoneTransfer

--- a/AD-Examples/EventLogScan.ps1
+++ b/AD-Examples/EventLogScan.ps1
@@ -1,0 +1,17 @@
+<#
+.SYNOPSIS
+    Scans event logs for recent Active Directory related errors and warnings.
+.DESCRIPTION
+    Retrieves critical and error events from Directory Service, DNS Server and System logs over the last 24 hours for review.
+#>
+
+$logs = @('Directory Service','DNS Server','System')
+$since = (Get-Date).AddHours(-24)
+
+Write-Host "=== Recent AD Related Events ===" -ForegroundColor Cyan
+foreach ($log in $logs) {
+    Write-Host "`n$log" -ForegroundColor Yellow
+    Get-WinEvent -LogName $log -ErrorAction SilentlyContinue |
+        Where-Object { $_.LevelDisplayName -in 'Critical','Error' -and $_.TimeCreated -ge $since } |
+        Select-Object TimeCreated, Id, LevelDisplayName, Message
+}

--- a/AD-Examples/GroupPolicyHealth.ps1
+++ b/AD-Examples/GroupPolicyHealth.ps1
@@ -1,0 +1,33 @@
+<#
+.SYNOPSIS
+    Validates Group Policy objects and link status across the domain.
+.DESCRIPTION
+    Checks that GPOs are linked and applied correctly and highlights any permission inconsistencies.
+#>
+
+Import-Module GroupPolicy
+Import-Module ActiveDirectory
+
+Write-Host "=== Group Policy Health ===" -ForegroundColor Cyan
+$gpos = Get-GPO -All
+foreach ($gpo in $gpos) {
+    $links = Get-GPOLink -Guid $gpo.Id -ErrorAction SilentlyContinue
+    if (-not $links) {
+        Write-Warning "$($gpo.DisplayName) has no links"
+    }
+}
+
+$permissionIssues = @()
+foreach ($gpo in $gpos) {
+    $acl = Get-GPPermission -Guid $gpo.Id -All
+    if ($acl | Where-Object { $_.Permission -eq 'GpoApply' -and $_.Denied }) {
+        $permissionIssues += $gpo.DisplayName
+    }
+}
+
+if ($permissionIssues) {
+    Write-Host "\nGPOs with permission issues:" -ForegroundColor Yellow
+    $permissionIssues
+} else {
+    Write-Host "\nNo permission issues found." -ForegroundColor Green
+}

--- a/AD-Examples/InactiveOrDisabledObjectsReport.ps1
+++ b/AD-Examples/InactiveOrDisabledObjectsReport.ps1
@@ -1,0 +1,28 @@
+<#
+.SYNOPSIS
+    Generates a report of inactive or disabled user and computer accounts.
+.DESCRIPTION
+    Finds accounts disabled or not logged in for a specified number of days and outputs the results.
+#>
+
+param(
+    [int]$InactiveDays = 90
+)
+
+Import-Module ActiveDirectory
+
+$since = (Get-Date).AddDays(-$InactiveDays)
+
+$disabled = Get-ADObject -LDAPFilter '(&(objectClass=user)(|(userAccountControl:1.2.840.113556.1.4.803:=2)(userAccountControl:1.2.840.113556.1.4.803:=16)))' -Properties samAccountName,whenChanged
+
+$inactiveUsers = Get-ADUser -Filter {Enabled -eq $true -and LastLogonDate -lt $since} -Properties LastLogonDate
+$inactiveComputers = Get-ADComputer -Filter {Enabled -eq $true -and LastLogonDate -lt $since} -Properties LastLogonDate
+
+Write-Host "=== Disabled Accounts ===" -ForegroundColor Cyan
+$disabled | Select-Object samAccountName,whenChanged | Format-Table -AutoSize
+
+Write-Host "\n=== Inactive Users ===" -ForegroundColor Cyan
+$inactiveUsers | Select-Object SamAccountName,LastLogonDate | Format-Table -AutoSize
+
+Write-Host "\n=== Inactive Computers ===" -ForegroundColor Cyan
+$inactiveComputers | Select-Object SamAccountName,LastLogonDate | Format-Table -AutoSize

--- a/AD-Examples/PasswordExpirationReport.ps1
+++ b/AD-Examples/PasswordExpirationReport.ps1
@@ -1,0 +1,32 @@
+<#
+.SYNOPSIS
+    Reports on user accounts with passwords expiring soon.
+.DESCRIPTION
+    Lists users whose passwords will expire within a specified number of days or have not been changed for an extended period.
+#>
+
+param(
+    [int]$ExpiresInDays = 14,
+    [int]$StaleAfterDays = 90
+)
+
+Import-Module ActiveDirectory
+
+$now = Get-Date
+$expireThreshold = $now.AddDays($ExpiresInDays)
+$staleThreshold = $now.AddDays(-$StaleAfterDays)
+
+$users = Get-ADUser -Filter {Enabled -eq $true -and PasswordNeverExpires -eq $false} -Properties DisplayName,PasswordLastSet,PasswordNeverExpires,msDS-UserPasswordExpiryTimeComputed
+
+$results = foreach ($u in $users) {
+    $expiry = [datetime]::FromFileTime($u.'msDS-UserPasswordExpiryTimeComputed')
+    if ($expiry -le $expireThreshold -or $u.PasswordLastSet -le $staleThreshold) {
+        [PSCustomObject]@{
+            User            = $u.DisplayName
+            PasswordExpires = $expiry
+            PasswordLastSet = $u.PasswordLastSet
+        }
+    }
+}
+
+$results | Sort-Object PasswordExpires | Format-Table -AutoSize

--- a/AD-Examples/ReplicationHealthCheck.ps1
+++ b/AD-Examples/ReplicationHealthCheck.ps1
@@ -1,0 +1,29 @@
+<#
+.SYNOPSIS
+    Checks Active Directory replication health across all domain controllers.
+.DESCRIPTION
+    Reports replication partner status, lingering objects, and any replication failures found in the forest.
+#>
+
+Import-Module ActiveDirectory
+
+$dcs = Get-ADDomainController -Filter *
+
+Write-Host "=== Replication Status ===" -ForegroundColor Cyan
+foreach ($dc in $dcs) {
+    Write-Host "`n$($dc.HostName)" -ForegroundColor Yellow
+    Get-ADReplicationPartnerMetadata -Target $dc.HostName -Scope Server |
+        Select-Object Partner, LastReplicationSuccess, LastReplicationResult, ConsecutiveReplicationFailures
+}
+
+Write-Host "`n=== Replication Failures ===" -ForegroundColor Cyan
+Get-ADReplicationFailure -Scope Forest |
+    Select-Object Server, FirstFailureTime, FailureCount, FailureType
+
+Write-Host "`n=== Lingering Objects ===" -ForegroundColor Cyan
+foreach ($dc in $dcs) {
+    $lingering = Get-ADReplicationLingeringObject -Server $dc.HostName -NamingContext (Get-ADDomain).DistinguishedName -ErrorAction SilentlyContinue
+    if ($lingering) {
+        $lingering | Select-Object Server, DistinguishedName, LastOriginatingChangeTime
+    }
+}

--- a/AD-Examples/SecurityBaselineCheck.ps1
+++ b/AD-Examples/SecurityBaselineCheck.ps1
@@ -1,0 +1,21 @@
+<#
+.SYNOPSIS
+    Audits key security settings for compliance with recommended best practices.
+.DESCRIPTION
+    Checks password complexity, account lockout policy, and other common security baseline settings.
+#>
+
+Import-Module ActiveDirectory
+
+Write-Host "=== Security Baseline ===" -ForegroundColor Cyan
+
+$passwordPolicy = Get-ADDefaultDomainPasswordPolicy
+
+[PSCustomObject]@{
+    MinPasswordLength       = $passwordPolicy.MinPasswordLength
+    PasswordHistoryCount    = $passwordPolicy.PasswordHistoryCount
+    ComplexityEnabled       = $passwordPolicy.ComplexityEnabled
+    LockoutThreshold        = $passwordPolicy.LockoutThreshold
+    LockoutDurationMinutes  = $passwordPolicy.LockoutDuration.TotalMinutes
+    LockoutObservationWindow = $passwordPolicy.LockoutObservationWindow.TotalMinutes
+}


### PR DESCRIPTION
## Summary
- add ReplicationHealthCheck.ps1 for checking AD replication
- add DnsHealthCheck.ps1 for verifying DNS health
- add DcServicesStatus.ps1 to confirm DC services are running
- add EventLogScan.ps1 for gathering AD-related errors
- add PasswordExpirationReport.ps1 for upcoming password expirations
- add InactiveOrDisabledObjectsReport.ps1 for inactive/disabled objects
- add GroupPolicyHealth.ps1 for GPO validation
- add SecurityBaselineCheck.ps1 for auditing password policy

## Testing
- `pwsh -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877edece2e8832aa3cf9a3230518198